### PR TITLE
fix: Function to skip Tests if no Environment Variable defined

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,12 @@ jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
-    # env:
-    #   PROXMOX_HOST: ${{ secrets.PROXMOX_HOST }}
-    #   PROXMOX_PORT: ${{ secrets.PROXMOX_PORT }}
-    #   PROXMOX_USERNAME: ${{ secrets.PROXMOX_USERNAME }}
-    #   PROXMOX_PASSWORD: ${{ secrets.PROXMOX_PASSWORD }}
-    #   PROXMOX_REALM: ${{ secrets.PROXMOX_REALM }}
+    env:
+      PROXMOX_HOST: ${{ secrets.PROXMOX_HOST }}
+      PROXMOX_PORT: ${{ secrets.PROXMOX_PORT }}
+      PROXMOX_USERNAME: ${{ secrets.PROXMOX_USERNAME }}
+      PROXMOX_PASSWORD: ${{ secrets.PROXMOX_PASSWORD }}
+      PROXMOX_REALM: ${{ secrets.PROXMOX_REALM }}
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -43,12 +43,12 @@ jobs:
   coverage:
     name: Code coverage
     runs-on: ubuntu-latest
-    # env:
-    #   PROXMOX_HOST: ${{ secrets.PROXMOX_HOST }}
-    #   PROXMOX_PORT: ${{ secrets.PROXMOX_PORT }}
-    #   PROXMOX_USERNAME: ${{ secrets.PROXMOX_USERNAME }}
-    #   PROXMOX_PASSWORD: ${{ secrets.PROXMOX_PASSWORD }}
-    #   PROXMOX_REALM: ${{ secrets.PROXMOX_REALM }}
+    env:
+      PROXMOX_HOST: ${{ secrets.PROXMOX_HOST }}
+      PROXMOX_PORT: ${{ secrets.PROXMOX_PORT }}
+      PROXMOX_USERNAME: ${{ secrets.PROXMOX_USERNAME }}
+      PROXMOX_PASSWORD: ${{ secrets.PROXMOX_PASSWORD }}
+      PROXMOX_REALM: ${{ secrets.PROXMOX_REALM }}
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,12 @@ jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
-    env:
-      PROXMOX_HOST: ${{ secrets.PROXMOX_HOST }}
-      PROXMOX_PORT: ${{ secrets.PROXMOX_PORT }}
-      PROXMOX_USERNAME: ${{ secrets.PROXMOX_USERNAME }}
-      PROXMOX_PASSWORD: ${{ secrets.PROXMOX_PASSWORD }}
-      PROXMOX_REALM: ${{ secrets.PROXMOX_REALM }}
+    # env:
+    #   PROXMOX_HOST: ${{ secrets.PROXMOX_HOST }}
+    #   PROXMOX_PORT: ${{ secrets.PROXMOX_PORT }}
+    #   PROXMOX_USERNAME: ${{ secrets.PROXMOX_USERNAME }}
+    #   PROXMOX_PASSWORD: ${{ secrets.PROXMOX_PASSWORD }}
+    #   PROXMOX_REALM: ${{ secrets.PROXMOX_REALM }}
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -43,12 +43,12 @@ jobs:
   coverage:
     name: Code coverage
     runs-on: ubuntu-latest
-    env:
-      PROXMOX_HOST: ${{ secrets.PROXMOX_HOST }}
-      PROXMOX_PORT: ${{ secrets.PROXMOX_PORT }}
-      PROXMOX_USERNAME: ${{ secrets.PROXMOX_USERNAME }}
-      PROXMOX_PASSWORD: ${{ secrets.PROXMOX_PASSWORD }}
-      PROXMOX_REALM: ${{ secrets.PROXMOX_REALM }}
+    # env:
+    #   PROXMOX_HOST: ${{ secrets.PROXMOX_HOST }}
+    #   PROXMOX_PORT: ${{ secrets.PROXMOX_PORT }}
+    #   PROXMOX_USERNAME: ${{ secrets.PROXMOX_USERNAME }}
+    #   PROXMOX_PASSWORD: ${{ secrets.PROXMOX_PASSWORD }}
+    #   PROXMOX_REALM: ${{ secrets.PROXMOX_REALM }}
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/src/auth/application/service/login_service.rs
+++ b/src/auth/application/service/login_service.rs
@@ -212,11 +212,10 @@ mod tests {
         // for the case where the endpoint is unreachable
         let result = timeout(Duration::from_secs(5), service.execute(&invalid_connection)).await;
 
-        assert!(match result {
-            Ok(Err(ProxmoxError::Connection(_))) => true,
-            Err(_elapsed) => true,
-            _ => false,
-        });
+        assert!(matches!(
+            result,
+            Ok(Err(ProxmoxError::Connection(_))) | Err(_)
+        ));
     }
 
     // Temporal workaround until github actions secrets are available

--- a/src/auth/application/service/login_service.rs
+++ b/src/auth/application/service/login_service.rs
@@ -140,59 +140,44 @@ mod tests {
         .await
     }
 
-    #[tokio::test]
-    async fn test_login_success() {
-        if !has_proxmox_config() {
-            println!("Skipping integration test - no Proxmox configuration");
-            return;
-        }
+    // #[tokio::test]
+    // async fn test_login_success() {
+    //     let connection = setup_connection().await.unwrap();
+    //     let service = LoginService::new();
 
-        let connection = setup_connection().await.unwrap();
-        let service = LoginService::new();
+    //     let result = service.execute(&connection).await;
+    //     assert!(result.is_ok());
 
-        let result = service.execute(&connection).await;
-        assert!(result.is_ok());
+    //     let auth = result.unwrap();
+    //     assert!(auth.ticket().value().await.starts_with("PVE:"));
+    //     assert!(auth.csrf_token().is_some());
+    // }
 
-        let auth = result.unwrap();
-        assert!(auth.ticket().value().await.starts_with("PVE:"));
-        assert!(auth.csrf_token().is_some());
-    }
+    // #[tokio::test]
+    // async fn test_login_invalid_credentials() {
+    //     let mut connection = setup_connection().await.unwrap();
+    //     // Override with invalid password
+    //     connection = ProxmoxConnection::new(
+    //         connection.proxmox_host().clone(),
+    //         connection.proxmox_port().clone(),
+    //         connection.proxmox_username().clone(),
+    //         ProxmoxPassword::new("InvalidPassword123!".to_string())
+    //             .await
+    //             .unwrap(),
+    //         connection.proxmox_realm().clone(),
+    //         false,
+    //         true,
+    //     )
+    //     .await
+    //     .unwrap();
 
-    #[tokio::test]
-    async fn test_login_invalid_credentials() {
-        if !has_proxmox_config() {
-            println!("Skipping integration test - no Proxmox configuration");
-            return;
-        }
-
-        let mut connection = setup_connection().await.unwrap();
-        // Override with invalid password
-        connection = ProxmoxConnection::new(
-            connection.proxmox_host().clone(),
-            connection.proxmox_port().clone(),
-            connection.proxmox_username().clone(),
-            ProxmoxPassword::new("InvalidPassword123!".to_string())
-                .await
-                .unwrap(),
-            connection.proxmox_realm().clone(),
-            false,
-            true,
-        )
-        .await
-        .unwrap();
-
-        let service = LoginService::new();
-        let result = service.execute(&connection).await;
-        assert!(matches!(result, Err(ProxmoxError::Authentication(_))));
-    }
+    //     let service = LoginService::new();
+    //     let result = service.execute(&connection).await;
+    //     assert!(matches!(result, Err(ProxmoxError::Authentication(_))));
+    // }
 
     #[tokio::test]
     async fn test_login_invalid_endpoint() {
-        if !has_proxmox_config() {
-            println!("Skipping integration test - no Proxmox configuration");
-            return;
-        }
-
         let connection = setup_connection().await.unwrap();
         let service = LoginService::new();
 
@@ -216,15 +201,5 @@ mod tests {
             result,
             Ok(Err(ProxmoxError::Connection(_))) | Err(_)
         ));
-    }
-
-    // Temporal workaround until github actions secrets are available
-    // and running remote Proxmox VE for ci testing
-    fn has_proxmox_config() -> bool {
-        env::var("PROXMOX_HOST").is_ok()
-            && env::var("PROXMOX_PORT").is_ok()
-            && env::var("PROXMOX_USERNAME").is_ok()
-            && env::var("PROXMOX_PASSWORD").is_ok()
-            && env::var("PROXMOX_REALM").is_ok()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,41 +333,31 @@ mod tests {
 
     #[tokio::test]
     async fn test_client_builder() {
-        if !has_proxmox_config() {
-            println!("Skipping integration test - no Proxmox configuration");
-            return;
-        }
-
         setup();
 
         let client = setup_client().await;
         assert!(client.is_ok());
     }
 
-    #[tokio::test]
-    async fn test_client_authentication() {
-        if !has_proxmox_config() {
-            println!("Skipping integration test - no Proxmox configuration");
-            return;
-        }
+    // #[tokio::test]
+    // async fn test_client_authentication() {
+    //     setup();
 
-        setup();
+    //     let mut client = setup_client().await.unwrap();
+    //     assert!(!client.is_authenticated());
 
-        let mut client = setup_client().await.unwrap();
-        assert!(!client.is_authenticated());
+    //     let login_result = client.login().await;
+    //     assert!(login_result.is_ok());
+    //     assert!(client.is_authenticated());
+    // }
 
-        let login_result = client.login().await;
-        assert!(login_result.is_ok());
-        assert!(client.is_authenticated());
-    }
-
-    // Temporal workaround until github actions secrets are available
-    // and running remote Proxmox VE for ci testing
-    fn has_proxmox_config() -> bool {
-        env::var("PROXMOX_HOST").is_ok()
-            && env::var("PROXMOX_PORT").is_ok()
-            && env::var("PROXMOX_USERNAME").is_ok()
-            && env::var("PROXMOX_PASSWORD").is_ok()
-            && env::var("PROXMOX_REALM").is_ok()
-    }
+    // // Temporal workaround until github actions secrets are available
+    // // and running remote Proxmox VE for ci testing
+    // fn has_proxmox_config() -> bool {
+    //     env::var("PROXMOX_HOST").is_ok()
+    //         && env::var("PROXMOX_PORT").is_ok()
+    //         && env::var("PROXMOX_USERNAME").is_ok()
+    //         && env::var("PROXMOX_PASSWORD").is_ok()
+    //         && env::var("PROXMOX_REALM").is_ok()
+    // }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,12 +333,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_client_builder() {
-        setup();
-
         if !has_proxmox_config() {
             println!("Skipping integration test - no Proxmox configuration");
             return;
         }
+
+        setup();
 
         let client = setup_client().await;
         assert!(client.is_ok());
@@ -346,12 +346,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_client_authentication() {
-        setup();
-
         if !has_proxmox_config() {
             println!("Skipping integration test - no Proxmox configuration");
             return;
         }
+
+        setup();
 
         let mut client = setup_client().await.unwrap();
         assert!(!client.is_authenticated());


### PR DESCRIPTION

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
This PR addresses a bug in the client where the setup test was called before verifying if test environment variables where set or not.

## Related Issues
<!-- Link to related issues using #issue-number -->
N/A

## Testing
- [ ] Tests added
- [x] Tests passed
- [x] Linting passed
