### PR TITLE
feat: implement optional validation checks and delegate by default to server && simplified core logic for better dx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leeca_proxmox"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leeca_proxmox"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 authors = ["4rkh4m <4rkham@proton.me>"]
 description = "A modern, safe, and async-first SDK for interacting with Proxmox Virtual Environment servers"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! By default, only basic format checks are performed to ensure the values can be used in HTTP requests.
 //!
 //! # Example
-//! ```
+//! ```no_run
 //! use leeca_proxmox::{ProxmoxClient, ProxmoxResult};
 //!
 //! #[tokio::main]


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update

## Description
This PR introduces version **0.2.0**, a major refactor addressing community feedback and improving the overall API design. Key changes include:

- 🔓 **Validation is now opt‑in** – Password strength, DNS resolution, and reserved username blocking are disabled by default, respecting the server administrator’s policies (addresses feedback from @wez).
- 🧹 **Simplified value objects** – Removed the `ValueObject` trait and async locking; values are now plain structs with synchronous getters.
- 🏗️ **Builder improvements** – `ProxmoxClientBuilder` now defaults to secure HTTPS and accepts a custom `ValidationConfig`.
- 📦 **Integration tests** – Moved into `src/tests/`, marked `#[ignore]` by default, and can be run against a real Proxmox instance with `cargo test -- --ignored`.
- ✅ **Test coverage** – Added comprehensive unit tests for all value objects, builder logic, and `LoginService` (using `wiremock`), achieving >90% coverage.
- 📚 **Documentation** – Updated `README.md`, `CHANGELOG.md`, and `ROADMAP.md` to reflect the 0.2.0 changes.

## Related Issues
None

## Testing
- [x] Tests added (unit, integration, and mock tests)
- [x] Tests passed (44 unit tests, all green; integration tests ignored but verified)
- [x] Linting passed (cargo clippy & fmt)