### PR TITLE
feat: implement session persistence logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Client‑side rate limiting** - Configurable requests per second and burst size (via `.rate_limit()` builder method). Uses a token bucket algorithm that blocks asynchronously when limits are exceeded.
 - **Internal HTTP client (`ApiClient`)** – centralises all API requests, handles authentication headers and automatic ticket refresh on 401 responses.
-- **Session persistence groundwork** – `ApiClient` stores authentication state in an `Arc<RwLock>`, ready for save/load.
+- **Session persistence** – Ability to save the current authentication state (ticket and CSRF token) to a file and load it back. New async methods: `ProxmoxClient::save_session_to_file`, `load_session_from_file`. The builder now supports `with_session` to initialize a client with a previously saved session.
 
 ### Changed
 - **`ProxmoxClient` now uses `ApiClient` internally** – authentication state is managed by the new client.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +397,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -954,6 +970,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "url",
@@ -966,6 +983,12 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1415,6 +1438,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,6 +1726,19 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1.49.0", features = [
     "rt-multi-thread",
     "macros",
     "time",
+    "fs"
 ] }
 url = "2.5.8"
 zxcvbn = "3.1.0"
@@ -35,6 +36,7 @@ zxcvbn = "3.1.0"
 dotenvy = "0.15.7"
 mockall = "0.14.0"
 wiremock = "0.6.5"
+tempfile = "3.25.0"
 
 [profile.release]
 lto = true

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,16 +4,16 @@
 
 ### 0.3.0 (In Progress)
 - ✅ **HTTP Client Refactor**: Centralised request handling with automatic authentication and ticket refresh.
+- ✅ **Enhanced Security**
+  - ✅ Rate limiting (client‑side)
+  - ✅ Token refresh mechanism
+  - ✅ Session persistence
 - 🔄 **Resource Management** (next)
   - VM operations (start, stop, reboot, create, delete)
   - Container (LXC) operations
   - Storage management (list, create, delete)
   - Network configuration
   - Node management
-- 🔄 **Enhanced Security**
-  - ✅ Rate limiting (client‑side)
-  - Token refresh mechanism
-  - Session persistence
 
 ### 0.2.0 (Current Release)
 - ✅ **Validation overhaul**: All extra checks (password strength, DNS, reserved usernames) are now opt‑in, off by default.

--- a/examples/auth/login.rs
+++ b/examples/auth/login.rs
@@ -1,13 +1,19 @@
+//! Basic authentication flow against a Proxmox server.
+//!
+//! This program builds a `ProxmoxClient`, checks its initial authentication
+//! state, performs login, and then retrieves the issued session and CSRF tokens.
+
 use leeca_proxmox::{ProxmoxClient, ProxmoxResult};
 
 #[tokio::main]
 async fn main() -> ProxmoxResult<()> {
-    // Build client with Proxmox server details
+    // Build the client with server configuration and credentials.
     let mut client = ProxmoxClient::builder()
         .host("192.168.1.182")
         .port(8006)
         .credentials("leeca", "password", "pam")
         .secure(false) // HTTP for local development
+        .accept_invalid_certs(true) // Testing & Self signed certs
         // Optional validation:
         // .enable_password_strength(3)
         // .block_reserved_usernames()
@@ -20,35 +26,40 @@ async fn main() -> ProxmoxResult<()> {
     println!(
         "Initial state: {}",
         if client.is_authenticated().await {
-            "✅ Authenticated"
+            "Authenticated"
         } else {
-            "❌ Not authenticated"
+            "Not authenticated"
         }
     );
 
+    // Perform authentication against the Proxmox API.
     println!("\n📡 Connecting to Proxmox...");
     client.login().await?;
+
     println!(
         "Connection state: {}",
         if client.is_authenticated().await {
-            "✅ Authenticated"
+            "Authenticated"
         } else {
-            "❌ Failed"
+            "Failed"
         }
     );
 
+    // Retrieve the issued authentication ticket.
     if let Some(token) = client.auth_token().await {
         println!("\n🎟️  Session Token");
         println!("------------------------");
         println!("Value: {}", token.as_str());
     }
 
+    // Retrieve the CSRF prevention token used for state-changing operations.
     if let Some(csrf) = client.csrf_token().await {
-        println!("\n🛡️  CSRF Protection");
+        println!("\n🛡️  CSRF Token");
         println!("------------------------");
-        println!("Token: {}", csrf.as_str());
+        println!("Value: {}", csrf.as_str());
     }
 
-    println!("\n✨ Connection established successfully!\n");
+    println!("\nConnection established successfully.\n");
+
     Ok(())
 }

--- a/examples/auth/session_persistence.rs
+++ b/examples/auth/session_persistence.rs
@@ -1,0 +1,71 @@
+//! Session persistence workflow for a Proxmox client.
+//!
+//! This program authenticates against a Proxmox server, stores the session
+//! to disk, and then restores it into a new client instance without
+//! performing a second login.
+
+use leeca_proxmox::{ProxmoxClient, ProxmoxResult};
+use std::fs::File;
+
+#[tokio::main]
+async fn main() -> ProxmoxResult<()> {
+    let host = "192.168.1.182";
+    let port: u16 = 8006;
+    let username = "leeca";
+    let password = "password";
+    let realm = "pam";
+
+    // Build and authenticate the initial client.
+    let mut client = ProxmoxClient::builder()
+        .host(host)
+        .port(port)
+        .credentials(username, password, realm)
+        .secure(false) // HTTP for local development
+        .accept_invalid_certs(true) // Testing & self-signed certs
+        // Optional validation:
+        // .enable_password_strength(3)
+        // .block_reserved_usernames()
+        // ...
+        .build()
+        .await?;
+
+    client.login().await?;
+
+    println!(
+        "Logged in successfully. Ticket: {}",
+        client.auth_token().await.unwrap().as_str()
+    );
+
+    // Persist the authenticated session to disk asynchronously.
+    let session_path = "session.json";
+    client.save_session_to_file(session_path).await?;
+    println!("Session saved to {}", session_path);
+
+    // Create a new client instance and restore the session.
+    let session_file = File::open(session_path)?;
+    let new_client = ProxmoxClient::builder()
+        .host(host)
+        .port(port)
+        .credentials(username, password, realm)
+        .secure(false)
+        .with_session(session_file)
+        .await?
+        .build()
+        .await?;
+
+    println!(
+        "Session loaded. Authenticated: {}",
+        new_client.is_authenticated().await
+    );
+
+    // Ensure both clients share the same authentication token.
+    assert_eq!(
+        client.auth_token().await.unwrap().as_str(),
+        new_client.auth_token().await.unwrap().as_str()
+    );
+
+    // Remove the persisted session file.
+    std::fs::remove_file(session_path)?;
+
+    Ok(())
+}

--- a/src/core/domain/model/proxmox_auth.rs
+++ b/src/core/domain/model/proxmox_auth.rs
@@ -1,6 +1,8 @@
 use crate::core::domain::value_object::{ProxmoxCSRFToken, ProxmoxTicket};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone)]
+/// Authentication data containing a ticket and optional CSRF token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProxmoxAuth {
     ticket: ProxmoxTicket,
     csrf_token: Option<ProxmoxCSRFToken>,

--- a/src/core/domain/value_object/mod.rs
+++ b/src/core/domain/value_object/mod.rs
@@ -6,6 +6,7 @@ mod proxmox_realm;
 mod proxmox_ticket;
 mod proxmox_uri;
 mod proxmox_username;
+mod serde_helpers;
 
 pub use proxmox_csrf_token::ProxmoxCSRFToken;
 pub use proxmox_host::ProxmoxHost;

--- a/src/core/domain/value_object/serde_helpers.rs
+++ b/src/core/domain/value_object/serde_helpers.rs
@@ -1,0 +1,29 @@
+//! Serde helpers for custom serialization.
+
+use serde::{Deserialize, Deserializer, Serializer};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Serialization and deserialization for `SystemTime` as seconds since UNIX epoch.
+pub mod system_time {
+    use super::*;
+
+    /// Serialize a `SystemTime` as a u64 representing seconds since UNIX epoch.
+    pub fn serialize<S>(time: &SystemTime, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let duration = time
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| serde::ser::Error::custom("SystemTime before UNIX epoch"))?;
+        serializer.serialize_u64(duration.as_secs())
+    }
+
+    /// Deserialize a u64 representing seconds since UNIX epoch into a `SystemTime`.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<SystemTime, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let secs = u64::deserialize(deserializer)?;
+        Ok(UNIX_EPOCH + Duration::from_secs(secs))
+    }
+}

--- a/src/core/infrastructure/api_client.rs
+++ b/src/core/infrastructure/api_client.rs
@@ -455,7 +455,6 @@ mod tests {
         res1.unwrap();
         res2.unwrap();
         let elapsed = start.elapsed();
-        // Relajamos el umbral para CI
         assert!(elapsed < Duration::from_millis(500)); // should be nearly instant
 
         // Send third and fourth requests – they should be delayed to respect the 2/sec rate

--- a/src/tests/integration.rs
+++ b/src/tests/integration.rs
@@ -1,6 +1,7 @@
 use crate::{ProxmoxClient, ProxmoxResult};
 use dotenvy::dotenv;
 use std::env;
+use tempfile::NamedTempFile;
 
 fn setup() {
     dotenv().ok();
@@ -60,5 +61,58 @@ async fn test_integration_login_invalid_credentials() -> ProxmoxResult<()> {
     assert!(result.is_err());
     // Optionally check error type
     // assert!(matches!(result.unwrap_err(), ProxmoxError::Authentication(_)));
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires running Proxmox instance and environment variables"]
+async fn test_integration_session_persistence() -> ProxmoxResult<()> {
+    setup();
+    let host = env::var("PROXMOX_HOST").expect("PROXMOX_HOST not set");
+    let port: u16 = env::var("PROXMOX_PORT")
+        .expect("PROXMOX_PORT not set")
+        .parse()
+        .expect("invalid port");
+    let username = env::var("PROXMOX_USERNAME").expect("PROXMOX_USERNAME not set");
+    let password = env::var("PROXMOX_PASSWORD").expect("PROXMOX_PASSWORD not set");
+    let realm = env::var("PROXMOX_REALM").expect("PROXMOX_REALM not set");
+
+    // Create client and login
+    let mut client = ProxmoxClient::builder()
+        .host(&host)
+        .port(port)
+        .credentials(username.clone(), password.clone(), realm.clone())
+        .secure(true)
+        .accept_invalid_certs(true)
+        .build()
+        .await?;
+
+    client.login().await?;
+    assert!(client.is_authenticated().await);
+
+    // Save session to a temporary file
+    let temp_file = NamedTempFile::new().unwrap();
+    let path = temp_file.path().to_path_buf();
+    client.save_session_to_file(&path).await?;
+
+    // Create a new client with the same connection settings and load the session
+    let new_client = ProxmoxClient::builder()
+        .host(host)
+        .port(port)
+        .credentials(username, password, realm)
+        .secure(true)
+        .accept_invalid_certs(true)
+        .with_session(std::fs::File::open(&path)?)
+        .await?
+        .build()
+        .await?;
+
+    // Should be authenticated without calling login
+    assert!(new_client.is_authenticated().await);
+    assert_eq!(
+        client.auth_token().await.unwrap().as_str(),
+        new_client.auth_token().await.unwrap().as_str()
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
Implement the ability to save the current authentication state (ticket and CSRF token) to a file and load it back. New async methods: `ProxmoxClient::save_session_to_file`, `load_session_from_file`. The builder now supports `with_session` to initialize a client with a previously saved session.

## Related Issues
None

## Testing
- [x] Tests added
- [x] Tests passed
- [x] Linting passed
