### PR TITLE
feat(nodes): implement node management logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Node management operations** – New methods for node discovery and inspection:
+  - `ProxmoxClient::nodes()` – Lists all nodes in the cluster with basic information and resource usage.
+  - `ProxmoxClient::node_status(node)` – Retrieves detailed status for a specific node, including CPU, memory, swap, load average, and IO delay (`wait`).
+  - `ProxmoxClient::node_dns(node)` – Fetches DNS configuration (search domain and servers) for a node.
+- **Domain models** – Added `NodeListItem`, `NodeStatus`, `MemoryInfo`, and `NodeDnsConfig` to represent node data.
+- **Example** – `examples/node_management.rs` demonstrates listing nodes and retrieving status/DNS.
 - **Cluster resource discovery** – New method `ProxmoxClient::cluster_resources()` that returns a list of all resources (VMs, containers, storage, nodes) in the cluster. The response is strongly typed via the `ClusterResource` enum.
 - **Domain models** – Added `ClusterResource` enum and its variants `QemuResource`, `LxcResource`, `StorageResource`, `NodeResource` to represent the different resource types returned by the `/cluster/resources` endpoint.
 - **Example** – `examples/cluster_resources.rs` demonstrates how to list and categorize cluster resources.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ async fn main() -> ProxmoxResult<()> {
 }
 ```
 
+See the [authentication example](examples/auth/login.rs) for a complete demonstration.
+
 ### Enabling extra validation
 
 By default, only basic format checks are performed. To enable additional checks:
@@ -167,6 +169,8 @@ assert!(new_client.is_authenticated().await);
 
 The session data contains the ticket and CSRF token with their creation timestamps. It is serialized as JSON. You should store it securely (e.g., encrypted at rest) because it grants access to the Proxmox API.
 
+See the [session_persistence example](examples/auth/session_persistence.rs) for a complete demonstration.
+
 ### Discovering Cluster Resources
 
 Once authenticated, you can retrieve a unified list of all resources in the cluster – including VMs, containers, storage, and nodes – using the `cluster_resources()` method. This is particularly useful for discovering which nodes contain specific VMs before performing node‑level operations.
@@ -210,6 +214,33 @@ for resource in resources {
 ```
 
 The method returns a Vec<ClusterResource> where each variant contains both common fields (like node, id, name, status) and type‑specific fields (e.g., vmid for VMs, storage for storage). This allows you to programmatically inspect your Proxmox infrastructure without hard‑coding node names.
+
+See the [cluster_resources example](examples/resources/cluster_resources.rs) for a complete demonstration.
+
+### Node Management
+
+Once authenticated, you can inspect the nodes in your cluster:
+
+```rust
+// List all nodes
+let nodes = client.nodes().await?;
+for node in nodes {
+    println!("Node: {} (status: {})", node.node, node.status);
+}
+
+// Get detailed status of a specific node
+let status = client.node_status("pve1").await?;
+println!("CPU: {:.2}%, IO Delay: {:.2}%", 
+    status.cpu * 100.0, 
+    status.wait.unwrap_or(0.0) * 100.0
+);
+
+// Get DNS configuration
+let dns = client.node_dns("pve1").await?;
+println!("DNS servers: {:?}", dns.servers);
+```
+
+See the [node_management example](examples/resources/node_management.rs) for a complete demonstration.
 
 See the [examples](examples/) directory for more.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,7 @@
   - ✅ Token refresh mechanism
   - ✅ Session persistence
 - ✅ **Cluster resource discovery** – Unified view of all resources (VMs, containers, storage, nodes) via `/cluster/resources`.
+- ✅ **Node management** – List nodes, get node status, and retrieve DNS configuration via `/nodes`, `/nodes/{node}/status`, and `/nodes/{node}/dns` endpoints.
 - 🔄 **Resource Management** (next)
   - VM operations (start, stop, reboot, create, delete)
   - Container (LXC) operations

--- a/examples/resources/node_management.rs
+++ b/examples/resources/node_management.rs
@@ -1,0 +1,104 @@
+//! Node management operations using the Proxmox client.
+//!
+//! This program authenticates against a Proxmox server,
+//! lists all cluster nodes, retrieves detailed status
+//! information for the first node, and fetches its DNS configuration.
+
+use leeca_proxmox::{ProxmoxClient, ProxmoxResult};
+
+#[tokio::main]
+async fn main() -> ProxmoxResult<()> {
+    let host = "192.168.1.182";
+    let port: u16 = 8006;
+    let username = "leeca";
+    let password = "password";
+    let realm = "pam";
+
+    // Build the client with node management configuration.
+    let mut client = ProxmoxClient::builder()
+        .host(host)
+        .port(port)
+        .credentials(username, password, realm)
+        .secure(false) // HTTP for local development
+        .accept_invalid_certs(true) // Testing & self-signed certs
+        .build()
+        .await?;
+
+    // Authenticate against the Proxmox API.
+    client.login().await?;
+    println!("Authenticated successfully");
+
+    // 1. List all nodes in the cluster.
+    println!("\nListing all nodes:");
+    let nodes = client.nodes().await?;
+
+    for node in &nodes {
+        println!(
+            "  • {}: {} (CPU: {:.1}%, Memory: {:.1}/{:.1} GB, Uptime: {}s)",
+            node.node,
+            node.status,
+            node.cpu.unwrap_or(0.0) * 100.0,
+            node.mem.unwrap_or(0) as f64 / 1024.0 / 1024.0 / 1024.0,
+            node.maxmem.unwrap_or(0) as f64 / 1024.0 / 1024.0 / 1024.0,
+            node.uptime.unwrap_or(0)
+        );
+    }
+
+    if nodes.is_empty() {
+        println!("No nodes found.");
+        return Ok(());
+    }
+
+    // 2. Retrieve detailed status for the first node.
+    let first_node = &nodes[0].node;
+    println!("\nDetailed status for node '{}':", first_node);
+
+    let status = client.node_status(first_node).await?;
+
+    println!(
+        "  CPU: {:.2}%, IO Delay: {:.2}%",
+        status.cpu * 100.0,
+        status.wait.unwrap_or(0.0) * 100.0
+    );
+
+    println!(
+        "  Memory: {:.1}/{:.1} GB used",
+        status.memory.used as f64 / 1024.0 / 1024.0 / 1024.0,
+        status.memory.total as f64 / 1024.0 / 1024.0 / 1024.0
+    );
+
+    if let Some(swap) = &status.swap {
+        println!(
+            "  Swap: {:.1}/{:.1} GB used",
+            swap.used as f64 / 1024.0 / 1024.0 / 1024.0,
+            swap.total as f64 / 1024.0 / 1024.0 / 1024.0
+        );
+    }
+
+    println!("  Uptime: {} seconds", status.uptime);
+
+    if let Some(loadavg) = status.loadavg {
+        println!(
+            "  Load average: {:.2}, {:.2}, {:.2}",
+            loadavg[0], loadavg[1], loadavg[2]
+        );
+    }
+
+    if let Some(kversion) = status.kversion {
+        println!("  Kernel: {}", kversion);
+    }
+
+    // 3. Retrieve DNS configuration for the first node.
+    println!("\nDNS configuration for node '{}':", first_node);
+
+    let dns = client.node_dns(first_node).await?;
+
+    println!("  Search domain: {}", dns.domain);
+    println!("  DNS servers: {:?}", dns.servers);
+
+    if let Some(options) = dns.options {
+        println!("  Options: {:?}", options);
+    }
+
+    Ok(())
+}

--- a/src/core/domain/model/mod.rs
+++ b/src/core/domain/model/mod.rs
@@ -1,3 +1,6 @@
 pub(crate) mod cluster_resource;
+pub(crate) mod node_dns;
+pub(crate) mod node_list_item;
+pub(crate) mod node_status;
 pub(crate) mod proxmox_auth;
 pub(crate) mod proxmox_connection;

--- a/src/core/domain/model/node_dns.rs
+++ b/src/core/domain/model/node_dns.rs
@@ -1,0 +1,20 @@
+//! Domain model for node DNS configuration from the `/nodes/{node}/dns` endpoint.
+//!
+//! This module defines the DNS settings for a specific node.
+
+use serde::{Deserialize, Serialize};
+
+/// DNS configuration for a Proxmox node.
+///
+/// Returned by the `/api2/json/nodes/{node}/dns` endpoint.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct NodeDnsConfig {
+    /// DNS search domain (e.g., "example.com").
+    pub domain: String,
+    /// List of DNS server IP addresses.
+    pub servers: Vec<String>,
+    /// DNS options (if any).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<String>>,
+}

--- a/src/core/domain/model/node_list_item.rs
+++ b/src/core/domain/model/node_list_item.rs
@@ -1,0 +1,45 @@
+//! Domain model for node list items from the `/nodes` endpoint.
+//!
+//! This module defines the structure of a node as returned by the Proxmox API
+//! when listing all nodes in the cluster.
+
+use serde::{Deserialize, Serialize};
+
+/// A node in the Proxmox cluster.
+///
+/// This struct represents a node as returned by the `/api2/json/nodes` endpoint.
+/// It contains identifying information, status, and resource usage statistics.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct NodeListItem {
+    /// The node name (e.g., "pve1").
+    pub node: String,
+    /// Current node status (e.g., "online", "offline", "unknown").
+    pub status: String,
+    /// CPU usage percentage (0.0 to 1.0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<f64>,
+    /// Maximum CPU count (number of cores/threads).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maxcpu: Option<u32>,
+    /// Memory usage in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mem: Option<u64>,
+    /// Maximum memory in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maxmem: Option<u64>,
+    /// Disk usage in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disk: Option<u64>,
+    /// Maximum disk space in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maxdisk: Option<u64>,
+    /// System uptime in seconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uptime: Option<u64>,
+    /// Unique node identifier (e.g., "node/pve1").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// SSL fingerprint (if available).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssl_fingerprint: Option<String>,
+}

--- a/src/core/domain/model/node_status.rs
+++ b/src/core/domain/model/node_status.rs
@@ -1,0 +1,53 @@
+//! Domain model for node status from the `/nodes/{node}/status` endpoint.
+//!
+//! This module defines the detailed status information for a specific node.
+
+use serde::{Deserialize, Serialize};
+
+/// Detailed status information for a Proxmox node.
+///
+/// Returned by the `/api2/json/nodes/{node}/status` endpoint.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct NodeStatus {
+    /// CPU usage percentage (0.0 to 1.0).
+    pub cpu: f64,
+    /// Memory usage in bytes.
+    pub memory: MemoryInfo,
+    /// Swap usage in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub swap: Option<MemoryInfo>,
+    /// System uptime in seconds.
+    pub uptime: u64,
+    /// Kernel version string.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kversion: Option<String>,
+    /// Load average over 1, 5, and 15 minutes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loadavg: Option<[f64; 3]>,
+    /// Current power state (e.g., "running").
+    pub current_kernel: Option<String>,
+    /// Node description (if set).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// IO delay percentage (0.0 to 1.0) - time spent waiting for I/O operations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wait: Option<f64>,
+    /// CPU information model string.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpuinfo: Option<String>,
+    /// Hardware model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pve_version: Option<String>,
+}
+
+/// Memory usage information.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct MemoryInfo {
+    /// Total memory in bytes.
+    pub total: u64,
+    /// Used memory in bytes.
+    pub used: u64,
+    /// Free memory in bytes.
+    pub free: u64,
+}

--- a/src/tests/resources/mod.rs
+++ b/src/tests/resources/mod.rs
@@ -1,1 +1,2 @@
 mod cluster_tests;
+mod node_tests;

--- a/src/tests/resources/node_tests.rs
+++ b/src/tests/resources/node_tests.rs
@@ -1,0 +1,335 @@
+use crate::{
+    ProxmoxClient, ProxmoxConnection, ProxmoxHost, ProxmoxPassword, ProxmoxPort, ProxmoxRealm,
+    ProxmoxUrl, ProxmoxUsername, ValidationConfig, core::infrastructure::api_client::ApiClient,
+};
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
+
+fn create_test_connection(server_url: &str) -> ProxmoxConnection {
+    let host = ProxmoxHost::new_unchecked(server_url.trim_start_matches("http://").to_string());
+    let port = ProxmoxPort::new_unchecked(8006);
+    let username = ProxmoxUsername::new_unchecked("testuser".to_string());
+    let password = ProxmoxPassword::new_unchecked("testpass".to_string());
+    let realm = ProxmoxRealm::new_unchecked("pam".to_string());
+    let url = ProxmoxUrl::new_unchecked(server_url.to_string() + "/");
+    ProxmoxConnection::new(host, port, username, password, realm, false, true, url)
+}
+
+async fn create_authenticated_client(mock_server: &MockServer) -> ApiClient {
+    let connection = create_test_connection(&mock_server.uri());
+    let config = ValidationConfig::default();
+    let client = ApiClient::new(connection, config).unwrap();
+
+    use crate::core::domain::value_object::{ProxmoxCSRFToken, ProxmoxTicket};
+    let ticket = ProxmoxTicket::new_unchecked("PVE:testuser@pam:4EEC61E2::sig".to_string());
+    let csrf = ProxmoxCSRFToken::new_unchecked("4EEC61E2:token".to_string());
+    let auth = crate::ProxmoxAuth::new(ticket, Some(csrf));
+    client.set_auth(auth).await;
+    client
+}
+
+#[tokio::test]
+async fn test_nodes_list_success() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("GET"))
+        .and(path("/api2/json/nodes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": [
+                {
+                    "node": "pve1",
+                    "status": "online",
+                    "cpu": 0.15,
+                    "maxcpu": 8,
+                    "mem": 8589934592_i64,
+                    "maxmem": 17179869184_i64,
+                    "disk": 1099511627776_i64,
+                    "maxdisk": 2199023255552_i64,
+                    "uptime": 1234567,
+                    "id": "node/pve1",
+                    "ssl_fingerprint": "AA:BB:CC:DD:EE:FF"
+                },
+                {
+                    "node": "pve2",
+                    "status": "online",
+                    "cpu": 0.08,
+                    "maxcpu": 16,
+                    "mem": 4294967296_i64,
+                    "maxmem": 34359738368_i64,
+                    "disk": 549755813888_i64,
+                    "maxdisk": 4398046511104_i64,
+                    "uptime": 987654,
+                    "id": "node/pve2"
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let nodes = proxmox_client.nodes().await.unwrap();
+    assert_eq!(nodes.len(), 2);
+
+    // Check first node
+    let node1 = &nodes[0];
+    assert_eq!(node1.node, "pve1");
+    assert_eq!(node1.status, "online");
+    assert_eq!(node1.cpu, Some(0.15));
+    assert_eq!(node1.maxcpu, Some(8));
+    assert_eq!(node1.mem, Some(8589934592));
+    assert_eq!(node1.maxmem, Some(17179869184));
+    assert_eq!(node1.disk, Some(1099511627776));
+    assert_eq!(node1.maxdisk, Some(2199023255552));
+    assert_eq!(node1.uptime, Some(1234567));
+    assert_eq!(node1.id.as_deref(), Some("node/pve1"));
+    assert_eq!(node1.ssl_fingerprint.as_deref(), Some("AA:BB:CC:DD:EE:FF"));
+
+    // Check second node
+    let node2 = &nodes[1];
+    assert_eq!(node2.node, "pve2");
+    assert_eq!(node2.status, "online");
+    assert_eq!(node2.cpu, Some(0.08));
+    assert_eq!(node2.maxcpu, Some(16));
+    assert_eq!(node2.mem, Some(4294967296));
+    assert_eq!(node2.maxmem, Some(34359738368));
+    assert_eq!(node2.disk, Some(549755813888));
+    assert_eq!(node2.maxdisk, Some(4398046511104));
+    assert_eq!(node2.uptime, Some(987654));
+    assert_eq!(node2.id.as_deref(), Some("node/pve2"));
+    assert_eq!(node2.ssl_fingerprint, None);
+}
+
+#[tokio::test]
+async fn test_nodes_list_empty() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("GET"))
+        .and(path("/api2/json/nodes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": []
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let nodes = proxmox_client.nodes().await.unwrap();
+    assert!(nodes.is_empty());
+}
+
+#[tokio::test]
+async fn test_node_status_success() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("GET"))
+        .and(path("/api2/json/nodes/pve1/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {
+                "cpu": 0.22,
+                "memory": {
+                    "total": 17179869184_i64,
+                    "used": 8589934592_i64,
+                    "free": 8589934592_i64
+                },
+                "swap": {
+                    "total": 4294967296_i64,
+                    "used": 0,
+                    "free": 4294967296_i64
+                },
+                "uptime": 1234567,
+                "kversion": "Linux 5.15.30-1-pve",
+                "loadavg": [1.2, 0.8, 0.5],
+                "current-kernel": "5.15.30-1-pve",
+                "description": "Main production node",
+                "wait": 0.03,
+                "cpuinfo": "Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz",
+                "pve-version": "7.3-1"
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let status = proxmox_client.node_status("pve1").await.unwrap();
+    assert_eq!(status.cpu, 0.22);
+    assert_eq!(status.memory.total, 17179869184);
+    assert_eq!(status.memory.used, 8589934592);
+    assert_eq!(status.memory.free, 8589934592);
+    assert_eq!(status.swap.as_ref().unwrap().total, 4294967296);
+    assert_eq!(status.swap.as_ref().unwrap().used, 0);
+    assert_eq!(status.swap.as_ref().unwrap().free, 4294967296);
+    assert_eq!(status.uptime, 1234567);
+    assert_eq!(status.kversion.as_deref(), Some("Linux 5.15.30-1-pve"));
+    assert_eq!(status.loadavg, Some([1.2, 0.8, 0.5]));
+    assert_eq!(status.wait, Some(0.03));
+    assert_eq!(
+        status.cpuinfo.as_deref(),
+        Some("Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz")
+    );
+    assert_eq!(status.pve_version.as_deref(), Some("7.3-1"));
+}
+
+#[tokio::test]
+async fn test_node_status_without_optional_fields() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("GET"))
+        .and(path("/api2/json/nodes/pve1/status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {
+                "cpu": 0.15,
+                "memory": {
+                    "total": 17179869184_i64,
+                    "used": 8589934592_i64,
+                    "free": 8589934592_i64
+                },
+                "uptime": 1234567,
+                "kversion": "Linux 5.15.30-1-pve"
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let status = proxmox_client.node_status("pve1").await.unwrap();
+    assert_eq!(status.cpu, 0.15);
+    assert_eq!(status.memory.total, 17179869184);
+    assert_eq!(status.memory.used, 8589934592);
+    assert_eq!(status.memory.free, 8589934592);
+    assert_eq!(status.uptime, 1234567);
+    assert_eq!(status.kversion.as_deref(), Some("Linux 5.15.30-1-pve"));
+    assert_eq!(status.swap, None);
+    assert_eq!(status.loadavg, None);
+    assert_eq!(status.wait, None);
+    assert_eq!(status.cpuinfo, None);
+    assert_eq!(status.pve_version, None);
+}
+
+#[tokio::test]
+async fn test_node_dns_success() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("GET"))
+        .and(path("/api2/json/nodes/pve1/dns"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {
+                "domain": "example.com",
+                "servers": ["8.8.8.8", "8.8.4.4"],
+                "options": ["rotate", "timeout:2"]
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let dns = proxmox_client.node_dns("pve1").await.unwrap();
+    assert_eq!(dns.domain, "example.com");
+    assert_eq!(
+        dns.servers,
+        vec!["8.8.8.8".to_string(), "8.8.4.4".to_string()]
+    );
+    assert_eq!(
+        dns.options,
+        Some(vec!["rotate".to_string(), "timeout:2".to_string()])
+    );
+}
+
+#[tokio::test]
+async fn test_node_dns_without_options() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("GET"))
+        .and(path("/api2/json/nodes/pve1/dns"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {
+                "domain": "example.com",
+                "servers": ["8.8.8.8"]
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let dns = proxmox_client.node_dns("pve1").await.unwrap();
+    assert_eq!(dns.domain, "example.com");
+    assert_eq!(dns.servers, vec!["8.8.8.8".to_string()]);
+    assert_eq!(dns.options, None);
+}
+
+#[tokio::test]
+async fn test_node_dns_unauthorized_triggers_refresh() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    // First request returns 401
+    Mock::given(method("GET"))
+        .and(path("/api2/json/nodes/pve1/dns"))
+        .respond_with(ResponseTemplate::new(401))
+        .up_to_n_times(1)
+        .mount(&mock_server)
+        .await;
+
+    // Login endpoint returns a new ticket
+    Mock::given(method("POST"))
+        .and(path("/api2/json/access/ticket"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {
+                "ticket": "PVE:testuser@pam:4EEC61E2::refreshed",
+                "CSRFPreventionToken": "4EEC61E2:newtoken"
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    // Second (retry) request succeeds
+    Mock::given(method("GET"))
+        .and(path("/api2/json/nodes/pve1/dns"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {
+                "domain": "example.com",
+                "servers": ["8.8.8.8"]
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let dns = proxmox_client.node_dns("pve1").await.unwrap();
+    assert_eq!(dns.domain, "example.com");
+    assert_eq!(dns.servers, vec!["8.8.8.8".to_string()]);
+}


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
- **Node management operations** – New methods for node discovery and inspection:
  - `ProxmoxClient::nodes()` – Lists all nodes in the cluster with basic information and resource usage.
  - `ProxmoxClient::node_status(node)` – Retrieves detailed status for a specific node, including CPU, memory, swap, load average, and IO delay (`wait`).
  - `ProxmoxClient::node_dns(node)` – Fetches DNS configuration (search domain and servers) for a node.
- **Domain models** – Added `NodeListItem`, `NodeStatus`, `MemoryInfo`, and `NodeDnsConfig` to represent node data.
- **Example** – `examples/node_management.rs` demonstrates listing nodes and retrieving status/DNS.

## Related Issues
None

## Testing
- [x] Tests added
- [x] Tests passed
- [x] Linting passed
