### PR TITLE
feat(vm): implement virtual machines operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **VM operations** – Complete set of methods for managing QEMU virtual machines:
+  - `vms(node)` – List all VMs on a node.
+  - `vm_status(node, vmid)` – Get detailed current status.
+  - `start_vm`, `stop_vm`, `shutdown_vm`, `reboot_vm`, `reset_vm` – Control VM state.
+  - `delete_vm(node, vmid, purge)` – Remove a VM.
+  - `create_vm(node, params)` – Create a new VM with full configuration.
+  - `vm_config(node, vmid)` – Get current configuration.
+  - `update_vm_config(node, vmid, params)` – Update configuration.
+- **Domain models** – Added `VmListItem`, `VmStatusCurrent`, `VmConfig`, `CreateVmParams` to represent VM data.
+- **Example** – `examples/vm_operations.rs` demonstrates listing, inspecting, and creating VMs.
 - **Node management operations** – New methods for node discovery and inspection:
   - `ProxmoxClient::nodes()` – Lists all nodes in the cluster with basic information and resource usage.
   - `ProxmoxClient::node_status(node)` – Retrieves detailed status for a specific node, including CPU, memory, swap, load average, and IO delay (`wait`).

--- a/README.md
+++ b/README.md
@@ -242,6 +242,38 @@ println!("DNS servers: {:?}", dns.servers);
 
 See the [node_management example](examples/resources/node_management.rs) for a complete demonstration.
 
+### VM Management
+
+After authentication, you can manage QEMU virtual machines on any node:
+
+```rust
+// List all VMs on a node
+let vms = client.vms("pve1").await?;
+for vm in vms {
+    println!("{} ({}): {}", vm.name, vm.vmid, vm.status);
+}
+
+// Get detailed status
+let status = client.vm_status("pve1", 100).await?;
+println!("CPU: {:.2}%", status.cpu.unwrap_or(0.0) * 100.0);
+
+// Start a VM
+let task = client.start_vm("pve1", 100).await?;
+println!("Task ID: {}", task);
+
+// Create a new VM
+let params = CreateVmParams {
+    vmid: 200,
+    name: "my-vm".to_string(),
+    memory: Some(4096),
+    cores: Some(2),
+    ..Default::default()
+};
+let task = client.create_vm("pve1", &params).await?;
+```
+
+See the [vm_operations example](examples/resources/vm_operations.rs) for a complete demonstration.
+
 See the [examples](examples/) directory for more.
 
 ## 🛠️ Development

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,7 @@
 ## Completed Versions
 
 ### 0.3.0 (In Progress)
+- ✅ **VM operations** – List, status, start, stop, shutdown, reboot, reset, delete, create, get/update config.
 - ✅ **HTTP Client Refactor**: Centralised request handling with automatic authentication and ticket refresh.
 - ✅ **Enhanced Security**
   - ✅ Rate limiting (client‑side)
@@ -11,11 +12,11 @@
 - ✅ **Cluster resource discovery** – Unified view of all resources (VMs, containers, storage, nodes) via `/cluster/resources`.
 - ✅ **Node management** – List nodes, get node status, and retrieve DNS configuration via `/nodes`, `/nodes/{node}/status`, and `/nodes/{node}/dns` endpoints.
 - 🔄 **Resource Management** (next)
-  - VM operations (start, stop, reboot, create, delete)
+  - ✅ VM operations (start, stop, reboot, create, delete)
   - Container (LXC) operations
   - Storage management (list, create, delete)
   - Network configuration
-  - Node management
+  - ✅ Node management
 
 ### 0.2.0 (Current Release)
 - ✅ **Validation overhaul**: All extra checks (password strength, DNS, reserved usernames) are now opt‑in, off by default.

--- a/examples/resources/vm_operations.rs
+++ b/examples/resources/vm_operations.rs
@@ -1,0 +1,153 @@
+//! Virtual machine management operations using the Proxmox client.
+//!
+//! This program authenticates against a Proxmox server,
+//! lists virtual machines on a node, retrieves detailed VM
+//! information, and demonstrates lifecycle and creation operations.
+
+use leeca_proxmox::{CreateVmParams, ProxmoxClient, ProxmoxResult};
+
+#[tokio::main]
+async fn main() -> ProxmoxResult<()> {
+    let host = "192.168.1.182";
+    let port: u16 = 8006;
+    let username = "leeca";
+    let password = "password";
+    let realm = "pam";
+
+    // Build the client with VM management configuration.
+    let mut client = ProxmoxClient::builder()
+        .host(host)
+        .port(port)
+        .credentials(username, password, realm)
+        .secure(false) // HTTP for local development
+        .accept_invalid_certs(true) // Testing & self-signed certs
+        .build()
+        .await?;
+
+    // Authenticate against the Proxmox API.
+    client.login().await?;
+    println!("Authenticated successfully");
+
+    // Target node.
+    let node = "pve1";
+
+    // 1. List all VMs on the node.
+    println!("\nListing VMs on node '{}':", node);
+    let vms = client.vms(node).await?;
+
+    for vm in &vms {
+        println!(
+            "  • VM {} (ID: {}): {} - CPU: {:.1}%, Mem: {:.1}/{:.1} GB, Uptime: {}s",
+            vm.name,
+            vm.vmid,
+            vm.status,
+            vm.cpu.unwrap_or(0.0) * 100.0,
+            vm.mem.unwrap_or(0) as f64 / 1024.0 / 1024.0 / 1024.0,
+            vm.maxmem.unwrap_or(0) as f64 / 1024.0 / 1024.0 / 1024.0,
+            vm.uptime.unwrap_or(0)
+        );
+    }
+
+    if vms.is_empty() {
+        println!("No VMs found on node '{}'.", node);
+    }
+
+    // 2. Retrieve detailed information for the first VM.
+    if let Some(first_vm) = vms.first() {
+        let vmid = first_vm.vmid;
+
+        println!("\nDetailed status for VM {} (ID: {}):", first_vm.name, vmid);
+        let status = client.vm_status(node, vmid).await?;
+
+        println!("  Status: {}", status.status);
+
+        if let Some(cpu) = status.cpu {
+            println!("  CPU: {:.2}%", cpu * 100.0);
+        }
+
+        if let Some(mem) = status.mem {
+            println!(
+                "  Memory: {:.1} GB used",
+                mem as f64 / 1024.0 / 1024.0 / 1024.0
+            );
+        }
+
+        if let Some(uptime) = status.uptime {
+            println!("  Uptime: {} seconds", uptime);
+        }
+
+        if let Some(balloon) = status.balloon {
+            println!(
+                "  Balloon: current={:.1} MB",
+                balloon.current as f64 / 1024.0 / 1024.0
+            );
+        }
+
+        // Retrieve VM configuration.
+        println!("\nConfiguration for VM {}:", first_vm.name);
+        let config = client.vm_config(node, vmid).await?;
+
+        println!("  Memory: {} MB", config.memory.unwrap_or(0));
+        println!(
+            "  CPU: {} sockets x {} cores",
+            config.sockets.unwrap_or(1),
+            config.cores.unwrap_or(1)
+        );
+        println!(
+            "  OS Type: {}",
+            config.ostype.as_deref().unwrap_or("unknown")
+        );
+        println!("  Tags: {}", config.tags.as_deref().unwrap_or("none"));
+
+        // Lifecycle operations (disabled by default).
+        /*
+        println!("\nStopping VM...");
+        let task = client.stop_vm(node, vmid).await?;
+        println!("  Task ID: {}", task);
+
+        println!("\nStarting VM...");
+        let task = client.start_vm(node, vmid).await?;
+        println!("  Task ID: {}", task);
+        */
+    }
+
+    // 3. Prepare parameters for VM creation.
+    println!("\nCreating a new VM (not executed):");
+
+    let params = CreateVmParams {
+        vmid: 9999,
+        name: "test-vm".to_string(),
+        memory: Some(2048),
+        sockets: Some(1),
+        cores: Some(2),
+        threads: None,
+        cpu: Some("host".to_string()),
+        ostype: Some("l26".to_string()),
+        kvm: Some(1),
+        numa: None,
+        net: Some("virtio,bridge=vmbr0".to_string()),
+        scsihw: Some("virtio-scsi-pci".to_string()),
+        boot: Some("order=scsi0;net0".to_string()),
+        start: Some(0),
+        tags: Some("example".to_string()),
+        description: Some("Created via ProxmoxClient".to_string()),
+        protection: None,
+        tablet: Some(1),
+        vga: Some("virtio".to_string()),
+        bios: None,
+        efidisk: None,
+        tpmstate: None,
+        agent: Some(1),
+    };
+
+    println!(
+        "  Prepared VM creation request for ID {} with name '{}'",
+        params.vmid, params.name
+    );
+
+    // Uncomment to execute:
+    // let task = client.create_vm(node, &params).await?;
+    // println!("  Task ID: {}", task);
+
+    Ok(())
+}

--- a/src/core/domain/model/mod.rs
+++ b/src/core/domain/model/mod.rs
@@ -4,3 +4,4 @@ pub(crate) mod node_list_item;
 pub(crate) mod node_status;
 pub(crate) mod proxmox_auth;
 pub(crate) mod proxmox_connection;
+pub(crate) mod vm;

--- a/src/core/domain/model/vm.rs
+++ b/src/core/domain/model/vm.rs
@@ -1,0 +1,278 @@
+//! Domain models for QEMU virtual machine operations.
+//!
+//! This module defines the structures used when interacting with VMs via the Proxmox API.
+
+use serde::{Deserialize, Serialize};
+
+/// A virtual machine as returned by the `/nodes/{node}/qemu` endpoint.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VmListItem {
+    /// The VM identifier (unique per cluster).
+    pub vmid: u32,
+    /// Human-readable name.
+    pub name: String,
+    /// Current status (e.g., "running", "stopped").
+    pub status: String,
+    /// CPU usage percentage (0.0 to 1.0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<f64>,
+    /// Maximum CPU count (number of cores/threads).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maxcpu: Option<u32>,
+    /// Memory usage in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mem: Option<u64>,
+    /// Maximum memory in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maxmem: Option<u64>,
+    /// Disk usage in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disk: Option<u64>,
+    /// Maximum disk space in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maxdisk: Option<u64>,
+    /// Uptime in seconds (if running).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uptime: Option<u64>,
+    /// The Proxmox node where this VM resides.
+    pub node: String,
+    /// Unique resource identifier (e.g., "qemu/100").
+    pub id: String,
+    /// Additional tags (if any).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags: Option<String>,
+}
+
+/// Detailed runtime status of a VM from `/nodes/{node}/qemu/{vmid}/status/current`.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct VmStatusCurrent {
+    /// Current VM status (e.g., "running", "stopped", "paused").
+    pub status: String,
+    /// VM name.
+    pub name: String,
+    /// CPU usage percentage (0.0 to 1.0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<f64>,
+    /// Memory usage in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mem: Option<u64>,
+    /// Uptime in seconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uptime: Option<u64>,
+    /// QEMU process status (e.g., "running", "stopped").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub qmpstatus: Option<String>,
+    /// Balloon info (optional).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub balloon: Option<BalloonInfo>,
+    /// Network interfaces (if available).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub net: Option<serde_json::Value>,
+    /// Block device statistics.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blockstat: Option<serde_json::Value>,
+    /// NUMA node memory info.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub numa: Option<serde_json::Value>,
+    /// Proxmox configuration digest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub digest: Option<String>,
+    /// Number of CPU sockets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sockets: Option<u32>,
+    /// Number of cores per socket.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cores: Option<u32>,
+    /// CPU type (e.g., "kvm64", "host").
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "cputype")]
+    pub cpu_type: Option<String>,
+    /// Balloon device minimum memory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub balloon_min: Option<u64>,
+    /// Maximum memory in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maxmem: Option<u64>,
+    /// Free CPU memory in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub freemem: Option<u64>,
+    /// Total memory in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub totalmem: Option<u64>,
+}
+
+/// Balloon device information.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BalloonInfo {
+    /// Current balloon size in bytes.
+    pub current: u64,
+    /// Maximum balloon size in bytes.
+    pub maximum: u64,
+    /// Minimum balloon size in bytes.
+    pub minimum: u64,
+}
+
+/// VM configuration from `/nodes/{node}/qemu/{vmid}/config`.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VmConfig {
+    /// VM identifier.
+    pub vmid: u32,
+    /// VM name.
+    pub name: String,
+    /// Description (if set).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Memory in MB.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<u32>,
+    /// Balloon device minimum memory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub balloon: Option<u32>,
+    /// Number of CPU sockets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sockets: Option<u32>,
+    /// Number of cores per socket.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cores: Option<u32>,
+    /// Number of threads per core.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub threads: Option<u32>,
+    /// CPU type.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<String>,
+    /// Network devices.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub net: Option<serde_json::Value>,
+    /// Storage devices.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scsi: Option<serde_json::Value>,
+    /// IDE devices.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ide: Option<serde_json::Value>,
+    /// SATA devices.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sata: Option<serde_json::Value>,
+    /// VirtIO devices.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub virtio: Option<serde_json::Value>,
+    /// Boot order.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub boot: Option<String>,
+    /// OS type.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ostype: Option<String>,
+    /// Agent enabled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<u8>,
+    /// KVM hardware virtualization enabled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kvm: Option<u8>,
+    /// NUMA enabled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub numa: Option<u8>,
+    /// Tags.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags: Option<String>,
+    /// Proxmox configuration digest (for updates).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub digest: Option<String>,
+    /// Start at boot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub onboot: Option<u8>,
+    /// Protection from accidental removal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protection: Option<u8>,
+    /// Tablet USB pointer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tablet: Option<u8>,
+    /// VGA configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vga: Option<String>,
+    /// SCSI controller type.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scsihw: Option<String>,
+    /// BIOS type (seabios, ovmf).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bios: Option<String>,
+    /// EFI disk (for OVMF).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub efidisk: Option<String>,
+    /// TPM state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tpmstate: Option<String>,
+}
+
+/// Parameters for creating a new VM.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateVmParams {
+    /// VM identifier (required, must be unique in the cluster).
+    pub vmid: u32,
+    /// VM name (required).
+    pub name: String,
+    /// Memory in MB (optional, default 512).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<u32>,
+    /// Number of CPU sockets (optional, default 1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sockets: Option<u32>,
+    /// Number of cores per socket (optional, default 1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cores: Option<u32>,
+    /// Number of threads per core (optional, default 1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub threads: Option<u32>,
+    /// CPU type (optional, default "kvm64").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<String>,
+    /// OS type (optional, e.g., "l26", "win10").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ostype: Option<String>,
+    /// Enable/disable KVM hardware virtualization (optional, default 1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kvm: Option<u8>,
+    /// Enable/disable NUMA (optional, default 0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub numa: Option<u8>,
+    /// Network configuration (optional, e.g., "virtio,bridge=vmbr0").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub net: Option<String>,
+    /// SCSI controller type (optional, e.g., "virtio-scsi-pci").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scsihw: Option<String>,
+    /// Boot order (optional, e.g., "order=scsi0;net0").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub boot: Option<String>,
+    /// Start after creation (optional, default 0).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start: Option<u8>,
+    /// Tags (optional).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags: Option<String>,
+    /// Description (optional).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Protection from accidental removal (optional).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protection: Option<u8>,
+    /// Tablet USB pointer (optional, default 1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tablet: Option<u8>,
+    /// VGA configuration (optional, e.g., "virtio").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vga: Option<String>,
+    /// BIOS type (optional, "seabios" or "ovmf").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bios: Option<String>,
+    /// EFI disk (optional, for OVMF).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub efidisk: Option<String>,
+    /// TPM state (optional).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tpmstate: Option<String>,
+    /// Agent enabled (optional, 1 to enable QEMU Guest Agent).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<u8>,
+}

--- a/src/tests/resources/mod.rs
+++ b/src/tests/resources/mod.rs
@@ -1,2 +1,3 @@
 mod cluster_tests;
 mod node_tests;
+mod vm_tests;

--- a/src/tests/resources/vm_tests.rs
+++ b/src/tests/resources/vm_tests.rs
@@ -1,0 +1,586 @@
+use crate::{
+    ProxmoxClient, ProxmoxConnection, ProxmoxHost, ProxmoxPassword, ProxmoxPort, ProxmoxRealm,
+    ProxmoxUrl, ProxmoxUsername, ValidationConfig, core::domain::model::vm::*,
+    core::infrastructure::api_client::ApiClient,
+};
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
+
+fn create_test_connection(server_url: &str) -> ProxmoxConnection {
+    let host = ProxmoxHost::new_unchecked(server_url.trim_start_matches("http://").to_string());
+    let port = ProxmoxPort::new_unchecked(8006);
+    let username = ProxmoxUsername::new_unchecked("testuser".to_string());
+    let password = ProxmoxPassword::new_unchecked("testpass".to_string());
+    let realm = ProxmoxRealm::new_unchecked("pam".to_string());
+    let url = ProxmoxUrl::new_unchecked(server_url.to_string() + "/");
+    ProxmoxConnection::new(host, port, username, password, realm, false, true, url)
+}
+
+async fn create_authenticated_client(mock_server: &MockServer) -> ApiClient {
+    let connection = create_test_connection(&mock_server.uri());
+    let config = ValidationConfig::default();
+    let client = ApiClient::new(connection, config).unwrap();
+
+    use crate::core::domain::value_object::{ProxmoxCSRFToken, ProxmoxTicket};
+    let ticket = ProxmoxTicket::new_unchecked("PVE:testuser@pam:4EEC61E2::sig".to_string());
+    let csrf = ProxmoxCSRFToken::new_unchecked("4EEC61E2:token".to_string());
+    let auth = crate::ProxmoxAuth::new(ticket, Some(csrf));
+    client.set_auth(auth).await;
+    client
+}
+
+#[tokio::test]
+async fn test_vms_list_success() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("GET"))
+        .and(path("/api2/json/nodes/pve1/qemu"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": [
+                {
+                    "vmid": 100,
+                    "name": "ubuntu-vm",
+                    "status": "running",
+                    "cpu": 0.23,
+                    "maxcpu": 4,
+                    "mem": 4294967296_i64,
+                    "maxmem": 8589934592_i64,
+                    "disk": 21474836480_i64,
+                    "maxdisk": 42949672960_i64,
+                    "uptime": 123456,
+                    "node": "pve1",
+                    "id": "qemu/100",
+                    "tags": "ubuntu,production"
+                },
+                {
+                    "vmid": 101,
+                    "name": "windows-vm",
+                    "status": "stopped",
+                    "maxcpu": 8,
+                    "maxmem": 17179869184_i64,
+                    "maxdisk": 107374182400_i64,
+                    "node": "pve1",
+                    "id": "qemu/101"
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let vms = proxmox_client.vms("pve1").await.unwrap();
+    assert_eq!(vms.len(), 2);
+
+    let vm1 = &vms[0];
+    assert_eq!(vm1.vmid, 100);
+    assert_eq!(vm1.name, "ubuntu-vm");
+    assert_eq!(vm1.status, "running");
+    assert_eq!(vm1.cpu, Some(0.23));
+    assert_eq!(vm1.maxcpu, Some(4));
+    assert_eq!(vm1.mem, Some(4294967296));
+    assert_eq!(vm1.maxmem, Some(8589934592));
+    assert_eq!(vm1.disk, Some(21474836480));
+    assert_eq!(vm1.maxdisk, Some(42949672960));
+    assert_eq!(vm1.uptime, Some(123456));
+    assert_eq!(vm1.node, "pve1");
+    assert_eq!(vm1.id, "qemu/100");
+    assert_eq!(vm1.tags.as_deref(), Some("ubuntu,production"));
+
+    let vm2 = &vms[1];
+    assert_eq!(vm2.vmid, 101);
+    assert_eq!(vm2.name, "windows-vm");
+    assert_eq!(vm2.status, "stopped");
+    assert_eq!(vm2.cpu, None);
+    assert_eq!(vm2.maxcpu, Some(8));
+    assert_eq!(vm2.mem, None);
+    assert_eq!(vm2.maxmem, Some(17179869184));
+    assert_eq!(vm2.disk, None);
+    assert_eq!(vm2.maxdisk, Some(107374182400));
+    assert_eq!(vm2.uptime, None);
+    assert_eq!(vm2.node, "pve1");
+    assert_eq!(vm2.id, "qemu/101");
+    assert_eq!(vm2.tags, None);
+}
+
+#[tokio::test]
+async fn test_vms_list_empty() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("GET"))
+        .and(path("/api2/json/nodes/pve1/qemu"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": []
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let vms = proxmox_client.vms("pve1").await.unwrap();
+    assert!(vms.is_empty());
+}
+
+#[tokio::test]
+async fn test_vm_status_success() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("GET"))
+        .and(path("/api2/json/nodes/pve1/qemu/100/status/current"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {
+                "status": "running",
+                "name": "ubuntu-vm",
+                "cpu": 0.15,
+                "mem": 4294967296_i64,
+                "uptime": 123456,
+                "qmpstatus": "running",
+                "balloon": {
+                    "current": 4294967296_i64,
+                    "maximum": 8589934592_i64,
+                    "minimum": 1073741824_i64
+                },
+                "sockets": 1,
+                "cores": 4,
+                "cputype": "kvm64",
+                "balloon_min": 1073741824_i64,
+                "maxmem": 8589934592_i64,
+                "freemem": 4294967296_i64,
+                "totalmem": 8589934592_i64,
+                "digest": "abc123"
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let status = proxmox_client.vm_status("pve1", 100).await.unwrap();
+    assert_eq!(status.status, "running");
+    assert_eq!(status.name, "ubuntu-vm");
+    assert_eq!(status.cpu, Some(0.15));
+    assert_eq!(status.mem, Some(4294967296));
+    assert_eq!(status.uptime, Some(123456));
+    assert_eq!(status.qmpstatus.as_deref(), Some("running"));
+    assert!(status.balloon.is_some());
+    assert_eq!(status.sockets, Some(1));
+    assert_eq!(status.cores, Some(4));
+    assert_eq!(status.cpu_type.as_deref(), Some("kvm64"));
+    assert_eq!(status.balloon_min, Some(1073741824));
+    assert_eq!(status.maxmem, Some(8589934592));
+    assert_eq!(status.freemem, Some(4294967296));
+    assert_eq!(status.totalmem, Some(8589934592));
+    assert_eq!(status.digest.as_deref(), Some("abc123"));
+}
+
+#[tokio::test]
+async fn test_vm_status_minimal() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("GET"))
+        .and(path("/api2/json/nodes/pve1/qemu/100/status/current"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {
+                "status": "stopped",
+                "name": "test-vm"
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let status = proxmox_client.vm_status("pve1", 100).await.unwrap();
+    assert_eq!(status.status, "stopped");
+    assert_eq!(status.name, "test-vm");
+    assert_eq!(status.cpu, None);
+    assert_eq!(status.mem, None);
+    assert_eq!(status.uptime, None);
+    assert_eq!(status.qmpstatus, None);
+}
+
+#[tokio::test]
+async fn test_start_vm_success() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("POST"))
+        .and(path("/api2/json/nodes/pve1/qemu/100/status/start"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": "UPID:pve1:00000001:00000001:00000001:start"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let task_id = proxmox_client.start_vm("pve1", 100).await.unwrap();
+    assert_eq!(task_id, "UPID:pve1:00000001:00000001:00000001:start");
+}
+
+#[tokio::test]
+async fn test_stop_vm_success() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("POST"))
+        .and(path("/api2/json/nodes/pve1/qemu/100/status/stop"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": "UPID:pve1:00000001:00000001:00000001:stop"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let task_id = proxmox_client.stop_vm("pve1", 100).await.unwrap();
+    assert_eq!(task_id, "UPID:pve1:00000001:00000001:00000001:stop");
+}
+
+#[tokio::test]
+async fn test_shutdown_vm_success() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("POST"))
+        .and(path("/api2/json/nodes/pve1/qemu/100/status/shutdown"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": "UPID:pve1:00000001:00000001:00000001:shutdown"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let task_id = proxmox_client.shutdown_vm("pve1", 100).await.unwrap();
+    assert_eq!(task_id, "UPID:pve1:00000001:00000001:00000001:shutdown");
+}
+
+#[tokio::test]
+async fn test_reboot_vm_success() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("POST"))
+        .and(path("/api2/json/nodes/pve1/qemu/100/status/reboot"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": "UPID:pve1:00000001:00000001:00000001:reboot"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let task_id = proxmox_client.reboot_vm("pve1", 100).await.unwrap();
+    assert_eq!(task_id, "UPID:pve1:00000001:00000001:00000001:reboot");
+}
+
+#[tokio::test]
+async fn test_reset_vm_success() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("POST"))
+        .and(path("/api2/json/nodes/pve1/qemu/100/status/reset"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": "UPID:pve1:00000001:00000001:00000001:reset"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let task_id = proxmox_client.reset_vm("pve1", 100).await.unwrap();
+    assert_eq!(task_id, "UPID:pve1:00000001:00000001:00000001:reset");
+}
+
+#[tokio::test]
+async fn test_delete_vm_with_purge() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/api2/json/nodes/pve1/qemu/100"))
+        .and(|req: &wiremock::Request| req.url.query() == Some("purge=1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": "UPID:pve1:00000001:00000001:00000001:delete"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let task_id = proxmox_client.delete_vm("pve1", 100, true).await.unwrap();
+    assert_eq!(task_id, "UPID:pve1:00000001:00000001:00000001:delete");
+}
+
+#[tokio::test]
+async fn test_delete_vm_without_purge() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/api2/json/nodes/pve1/qemu/100"))
+        .and(|req: &wiremock::Request| req.url.query() == Some("purge=0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": "UPID:pve1:00000001:00000001:00000001:delete"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let task_id = proxmox_client.delete_vm("pve1", 100, false).await.unwrap();
+    assert_eq!(task_id, "UPID:pve1:00000001:00000001:00000001:delete");
+}
+
+#[tokio::test]
+async fn test_create_vm_success() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("POST"))
+        .and(path("/api2/json/nodes/pve1/qemu"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": "UPID:pve1:00000001:00000001:00000001:create"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let params = CreateVmParams {
+        vmid: 100,
+        name: "test-vm".to_string(),
+        memory: Some(2048),
+        sockets: Some(1),
+        cores: Some(2),
+        threads: None,
+        cpu: Some("host".to_string()),
+        ostype: Some("l26".to_string()),
+        kvm: Some(1),
+        numa: None,
+        net: Some("virtio,bridge=vmbr0".to_string()),
+        scsihw: Some("virtio-scsi-pci".to_string()),
+        boot: Some("order=scsi0;net0".to_string()),
+        start: Some(1),
+        tags: Some("test".to_string()),
+        description: Some("Created by leeca".to_string()),
+        protection: None,
+        tablet: Some(1),
+        vga: Some("virtio".to_string()),
+        bios: None,
+        efidisk: None,
+        tpmstate: None,
+        agent: Some(1),
+    };
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let task_id = proxmox_client.create_vm("pve1", &params).await.unwrap();
+    assert_eq!(task_id, "UPID:pve1:00000001:00000001:00000001:create");
+}
+
+#[tokio::test]
+async fn test_vm_config_success() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("GET"))
+        .and(path("/api2/json/nodes/pve1/qemu/100/config"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {
+                "vmid": 100,
+                "name": "ubuntu-vm",
+                "description": "Production VM",
+                "memory": 4096,
+                "balloon": 1024,
+                "sockets": 1,
+                "cores": 4,
+                "threads": 1,
+                "cpu": "host",
+                "net": "virtio,bridge=vmbr0",
+                "scsi": "virtio,size=32G",
+                "boot": "order=scsi0;net0",
+                "ostype": "l26",
+                "agent": 1,
+                "kvm": 1,
+                "numa": 0,
+                "tags": "ubuntu,production",
+                "onboot": 1,
+                "protection": 0,
+                "tablet": 1,
+                "vga": "virtio",
+                "scsihw": "virtio-scsi-pci",
+                "bios": "seabios",
+                "digest": "abc123def456"
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let config = proxmox_client.vm_config("pve1", 100).await.unwrap();
+    assert_eq!(config.vmid, 100);
+    assert_eq!(config.name, "ubuntu-vm");
+    assert_eq!(config.description.as_deref(), Some("Production VM"));
+    assert_eq!(config.memory, Some(4096));
+    assert_eq!(config.balloon, Some(1024));
+    assert_eq!(config.sockets, Some(1));
+    assert_eq!(config.cores, Some(4));
+    assert_eq!(config.threads, Some(1));
+    assert_eq!(config.cpu.as_deref(), Some("host"));
+    assert!(config.net.is_some());
+    assert!(config.scsi.is_some());
+    assert_eq!(config.boot.as_deref(), Some("order=scsi0;net0"));
+    assert_eq!(config.ostype.as_deref(), Some("l26"));
+    assert_eq!(config.agent, Some(1));
+    assert_eq!(config.kvm, Some(1));
+    assert_eq!(config.numa, Some(0));
+    assert_eq!(config.tags.as_deref(), Some("ubuntu,production"));
+    assert_eq!(config.onboot, Some(1));
+    assert_eq!(config.protection, Some(0));
+    assert_eq!(config.tablet, Some(1));
+    assert_eq!(config.vga.as_deref(), Some("virtio"));
+    assert_eq!(config.scsihw.as_deref(), Some("virtio-scsi-pci"));
+    assert_eq!(config.bios.as_deref(), Some("seabios"));
+    assert_eq!(config.digest.as_deref(), Some("abc123def456"));
+}
+
+#[tokio::test]
+async fn test_update_vm_config_success() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    Mock::given(method("PUT"))
+        .and(path("/api2/json/nodes/pve1/qemu/100/config"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": "UPID:pve1:00000001:00000001:00000001:update"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let params = CreateVmParams {
+        vmid: 100,
+        name: "ubuntu-vm".to_string(),
+        memory: Some(8192),
+        sockets: Some(2),
+        cores: Some(4),
+        threads: None,
+        cpu: None,
+        ostype: None,
+        kvm: None,
+        numa: None,
+        net: None,
+        scsihw: None,
+        boot: None,
+        start: None,
+        tags: Some("updated".to_string()),
+        description: Some("Updated description".to_string()),
+        protection: Some(1),
+        tablet: None,
+        vga: None,
+        bios: None,
+        efidisk: None,
+        tpmstate: None,
+        agent: None,
+    };
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let task_id = proxmox_client
+        .update_vm_config("pve1", 100, &params)
+        .await
+        .unwrap();
+    assert_eq!(task_id, "UPID:pve1:00000001:00000001:00000001:update");
+}
+
+#[tokio::test]
+async fn test_vm_actions_unauthorized_triggers_refresh() {
+    let mock_server = MockServer::start().await;
+    let client = create_authenticated_client(&mock_server).await;
+
+    // First request returns 401
+    Mock::given(method("POST"))
+        .and(path("/api2/json/nodes/pve1/qemu/100/status/start"))
+        .respond_with(ResponseTemplate::new(401))
+        .up_to_n_times(1)
+        .mount(&mock_server)
+        .await;
+
+    // Login endpoint returns a new ticket
+    Mock::given(method("POST"))
+        .and(path("/api2/json/access/ticket"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {
+                "ticket": "PVE:testuser@pam:4EEC61E2::refreshed",
+                "CSRFPreventionToken": "4EEC61E2:newtoken"
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    // Second (retry) request succeeds
+    Mock::given(method("POST"))
+        .and(path("/api2/json/nodes/pve1/qemu/100/status/start"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": "UPID:pve1:00000001:00000001:00000001:start"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let proxmox_client = ProxmoxClient {
+        api_client: client,
+        config: ValidationConfig::default(),
+    };
+
+    let task_id = proxmox_client.start_vm("pve1", 100).await.unwrap();
+    assert_eq!(task_id, "UPID:pve1:00000001:00000001:00000001:start");
+}


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
- **VM operations** – Complete set of methods for managing QEMU virtual machines:
  - `vms(node)` – List all VMs on a node.
  - `vm_status(node, vmid)` – Get detailed current status.
  - `start_vm`, `stop_vm`, `shutdown_vm`, `reboot_vm`, `reset_vm` – Control VM state.
  - `delete_vm(node, vmid, purge)` – Remove a VM.
  - `create_vm(node, params)` – Create a new VM with full configuration.
  - `vm_config(node, vmid)` – Get current configuration.
  - `update_vm_config(node, vmid, params)` – Update configuration.

## Related Issues
None

## Testing
- [x] Tests added
- [x] Tests passed
- [x] Linting passed
